### PR TITLE
fix(token): fixes to be OAuth compliant

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "release": "yarn publish --access public"
   },
   "dependencies": {
-    "axios": "^0.21.1"
+    "axios": "^0.21.1",
+    "qs": "^6.10.1"
   },
   "devDependencies": {
     "jest": "^26.6.3",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -12,5 +12,5 @@ export default {
       sourcemap: true
     }
   ],
-  external: ['axios']
+  external: ['axios', 'qs']
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,6 @@
 import axios from 'axios'
 import { convertObjectToCamelCase } from './formatting'
 
-const EXPIRATION_LIMIT_SECONDS = 10
-
 const Method = {
   POST: 'post',
   GET: 'get'
@@ -129,7 +127,7 @@ export class IncogniaAPI {
     const createdAt = this.incogniaToken.createdAt
     const expiresIn = this.incogniaToken.expiresIn
 
-    const expirationLimit = createdAt + expiresIn + EXPIRATION_LIMIT_SECONDS
+    const expirationLimit = createdAt + expiresIn
     const nowInSeconds = Math.round(Date.now() / 1000)
 
     if (expirationLimit <= nowInSeconds) {

--- a/src/index.js
+++ b/src/index.js
@@ -95,7 +95,7 @@ export class IncogniaAPI {
         ...options,
         headers: {
           'Content-Type': 'application/json',
-          Authorization: `Bearer ${this.incogniaToken.accessToken}`
+          Authorization: `${this.incogniaToken.tokenType} ${this.incogniaToken.accessToken}`
         }
       })
       return convertObjectToCamelCase(response.data)
@@ -114,7 +114,8 @@ export class IncogniaAPI {
       this.incogniaToken = {
         createdAt: Math.round(Date.now() / 1000),
         expiresIn: parseInt(data.expires_in),
-        accessToken: data.access_token
+        accessToken: data.access_token,
+        tokenType: data.token_type
       }
     } catch (e) {
       throw new Error('Could not request the AccessToken: ' + e.message)

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import axios from 'axios'
+import qs from 'qs'
 import { convertObjectToCamelCase } from './formatting'
 
 const Method = {
@@ -142,9 +143,7 @@ export class IncogniaAPI {
     return axios({
       method: Method.POST,
       url: this.apiEndpoints.TOKEN,
-      data: {
-        grant_type: 'client_credentials'
-      },
+      data: qs.stringify({ grant_type: 'client_credentials' }),
       auth: {
         username: this.clientId,
         password: this.clientSecret

--- a/src/index.js
+++ b/src/index.js
@@ -143,6 +143,9 @@ export class IncogniaAPI {
     return axios({
       method: Method.POST,
       url: this.apiEndpoints.TOKEN,
+      data: {
+        grant_type: 'client_credentials'
+      },
       auth: {
         username: this.clientId,
         password: this.clientSecret

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -11,13 +11,15 @@ const accessTokenExample = {
   expires_in: 20 * 60
 }
 
+const credentials = {
+  clientId: 'clientId',
+  clientSecret: 'clientSecret'
+}
+
 describe('API', () => {
   beforeEach(() => {
     nock.cleanAll()
-    incogniaAPI = new IncogniaAPI({
-      clientId: 'clientId',
-      clientSecret: 'clientSecret'
-    })
+    incogniaAPI = new IncogniaAPI(credentials)
   })
 
   describe('Regions', () => {
@@ -155,6 +157,23 @@ describe('API', () => {
 
   describe('Access token managament', () => {
     describe('when calling the api ', () => {
+      it('calls access token endpoint with creds', async () => {
+        const accessTokenEndpointCall = nock(US_BASE_ENDPOINT_URL, {
+            reqheaders: {
+              'Content-Type': 'application/x-www-form-urlencoded'
+            }
+          })
+          .post('/v1/token', { grant_type: 'client_credentials' })
+          .basicAuth({
+            user: credentials.clientId,
+            pass: credentials.clientSecret
+          })
+          .reply(200, accessTokenExample)
+
+        await incogniaAPI.requestToken()
+        expect(accessTokenEndpointCall.isDone()).toBeTruthy()
+      })
+
       it('calls access token endpoint only at the first time', async () => {
         const signupId = 123
         const accessTokenEndpointFirstCall = nock(US_BASE_ENDPOINT_URL)

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -8,7 +8,8 @@ let incogniaAPI
 
 const accessTokenExample = {
   access_token: 'access_token',
-  expires_in: 20 * 60
+  expires_in: 20 * 60,
+  token_type: 'Bearer'
 }
 
 const credentials = {
@@ -79,6 +80,28 @@ describe('API', () => {
         .post('/v1/token')
         .reply(200, accessTokenExample)
     })
+
+    it('informs Authorization header when requesting resource', async () => {
+      const expectedAuthorizationHeader = `${accessTokenExample.token_type} ${accessTokenExample.access_token}`
+
+      const resourceRequest = nock(US_BASE_ENDPOINT_URL, {
+          reqheaders: {
+            'Content-Type': 'application/json',
+            Authorization: expectedAuthorizationHeader
+          }
+        })
+        .persist()
+        .get(`/someUrl`)
+        .reply(200, {})
+
+      await incogniaAPI.resourceRequest({
+        url: `${US_BASE_ENDPOINT_URL}/someUrl`,
+        method: 'get',
+      })
+
+      expect(resourceRequest.isDone()).toBeTruthy()
+    })
+
     it('gets onboarding assessment', async () => {
       const apiResponse = {
         id: '5e76a7ca-577c-4f47-a752-9e1e0cee9e49',

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -214,7 +214,14 @@ describe('API', () => {
 
         Date.now = jest.fn(() => new Date(Date.UTC(2021, 3, 14)).valueOf())
         await incogniaAPI.updateAccessToken()
-        Date.now = jest.fn(() => new Date(Date.UTC(2021, 3, 15)).valueOf())
+        Date.now = jest.fn(
+          () => {
+            var date = new Date(Date.UTC(2021, 3, 14))
+            date.setUTCSeconds(accessTokenExample.expires_in)
+
+            return date.valueOf()
+          }
+        )
         expect(incogniaAPI.isAccessTokenValid()).toEqual(false)
       })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -902,6 +902,14 @@ cache-base@^1.0.1:
     union-value "^1.0.0"
     unset-value "^1.0.0"
 
+call-bind@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.2.tgz#b1d4e89e688119c3c9a903ad30abb2f6a919be3c"
+  integrity sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==
+  dependencies:
+    function-bind "^1.1.1"
+    get-intrinsic "^1.0.2"
+
 callsites@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
@@ -1496,6 +1504,15 @@ get-caller-file@^2.0.1:
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
+get-intrinsic@^1.0.2:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.1.1.tgz#15f59f376f855c446963948f0d24cd3637b4abc6"
+  integrity sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==
+  dependencies:
+    function-bind "^1.1.1"
+    has "^1.0.3"
+    has-symbols "^1.0.1"
+
 get-package-type@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/get-package-type/-/get-package-type-0.1.0.tgz#8de2d803cff44df3bc6c456e6668b36c3926e11a"
@@ -1576,6 +1593,11 @@ has-flag@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
   integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
+
+has-symbols@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.2.tgz#165d3070c00309752a1236a479331e3ac56f1423"
+  integrity sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==
 
 has-value@^0.3.1:
   version "0.3.1"
@@ -2660,6 +2682,11 @@ object-copy@^0.1.0:
     define-property "^0.2.5"
     kind-of "^3.0.3"
 
+object-inspect@^1.9.0:
+  version "1.10.3"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.10.3.tgz#c2aa7d2d09f50c99375704f7a0adf24c5782d369"
+  integrity sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw==
+
 object-visit@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/object-visit/-/object-visit-1.0.1.tgz#f79c4493af0c5377b59fe39d395e41042dd045bb"
@@ -2853,6 +2880,13 @@ punycode@^2.1.0, punycode@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
+
+qs@^6.10.1:
+  version "6.10.1"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.10.1.tgz#4931482fa8d647a5aab799c5271d2133b981fb6a"
+  integrity sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==
+  dependencies:
+    side-channel "^1.0.4"
 
 qs@~6.5.2:
   version "6.5.2"
@@ -3118,6 +3152,15 @@ shellwords@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
+
+side-channel@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.0.4.tgz#efce5c8fdc104ee751b25c58d4290011fa5ea2cf"
+  integrity sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==
+  dependencies:
+    call-bind "^1.0.0"
+    get-intrinsic "^1.0.2"
+    object-inspect "^1.9.0"
 
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.3"


### PR DESCRIPTION
Fixes to be [OAuth compliant](https://datatracker.ietf.org/doc/html/rfc6749).

- adds `grant_type` to body request
- removes the additional expiration time frame
- use `token_type` from token request

Review per commit can be easier.