### PR TITLE
feat(errors): add Incognia custom errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,30 @@ Responses have JSONs identical to the original api <https://us.incognia.com>, **
 }
 ```
 
+## Exception handling
+
+Every method call can throw `IncogniaAPIError` and `IncogniaError`.
+
+`IncogniaAPIError` is thrown when the API returned an unexpected http status code. You can retrieve it by calling the `statusCode` property, along with the `payload` property, which returns the API response payload that might include additional details.
+
+`IncogniaError` represents unknown errors, like serialization/deserialization errors.
+
+```js
+const { IncogniaAPI, IncogniaAPIError } = require('@incognia/api')
+
+try {
+  const loginAssessment = await incogniaAPI.registerLoginAssessment({
+    installationId: 'installation_id',
+    accountId: 'account_id'
+  })
+} catch (error) {
+  if (error instanceof IncogniaAPIError) {
+    console.log(error.statusCode)
+    console.log(error.payload)
+  }
+}
+```
+
 ## More documentation
 
 More documentation and code examples can be found at <https://us.incognia.com>

--- a/src/errors.js
+++ b/src/errors.js
@@ -1,0 +1,37 @@
+export class IncogniaAPIError extends Error {
+  constructor(message, options) {
+    super(message)
+    this.name = 'IncogniaAPIError'
+    this.statusCode = options && options.statusCode
+    this.payload = options && options.payload
+  }
+}
+
+export class IncogniaError extends Error {
+  constructor(message) {
+    super(message)
+    this.name = 'IncogniaError'
+  }
+}
+
+export function handleRequestError(e) {
+  var error
+
+  if (e.response) {
+    error = new IncogniaAPIError(
+      e.message,
+      {
+        statusCode: e.response.status,
+        payload: e.response.data
+      }
+    )
+  } else if (e.request) {
+    error = new IncogniaAPIError(
+      `The request was made but no response was received (${e.message})`
+    )
+  } else {
+    error = new IncogniaError(e.message)
+  }
+
+  throw error
+}

--- a/src/errors.js
+++ b/src/errors.js
@@ -14,24 +14,22 @@ export class IncogniaError extends Error {
   }
 }
 
-export function handleRequestError(e) {
-  var error
-
+export function throwCustomRequestError(e) {
   if (e.response) {
-    error = new IncogniaAPIError(
+    throw new IncogniaAPIError(
       e.message,
       {
         statusCode: e.response.status,
         payload: e.response.data
       }
     )
-  } else if (e.request) {
-    error = new IncogniaAPIError(
-      `The request was made but no response was received (${e.message})`
-    )
-  } else {
-    error = new IncogniaError(e.message)
   }
 
-  throw error
+  if (e.request) {
+    throw new IncogniaAPIError(
+      `The request was made but no response was received (${e.message})`
+    )
+  }
+
+  throw new IncogniaError(e.message)
 }

--- a/src/errors.test.js
+++ b/src/errors.test.js
@@ -1,0 +1,100 @@
+import { IncogniaAPIError, IncogniaError, handleRequestError } from './errors'
+
+describe('IncogniaAPIError', () => {
+  const error = new IncogniaAPIError('error message')
+
+  it('returns custom properties', () => {
+    expect(error.name).toEqual('IncogniaAPIError')
+    expect(error.message).toEqual('error message')
+    expect(error.statusCode).toBeUndefined()
+    expect(error.payload).toBeUndefined()
+  })
+
+  describe('when statusCode and payload are informed', () => {
+    const errorWithData = new IncogniaAPIError(
+      'error message',
+      {
+        statusCode: 400,
+        payload: 'error occured'
+      }
+    )
+
+    it('returns them', () => {
+      expect(errorWithData.statusCode).toEqual(400)
+      expect(errorWithData.payload).toEqual('error occured')
+    })
+  })
+})
+
+describe('IncogniaError', () => {
+  const error = new IncogniaError('error message')
+
+  it('returns error properties', () => {
+    expect(error.name).toEqual('IncogniaError')
+    expect(error.message).toEqual('error message')
+  })
+})
+
+describe('handleRequestError', () => {
+  describe('when the error contains a response', () => {
+    const error = {
+      message: 'error message',
+      response: {
+        status: 422,
+        data: 'server message'
+      }
+    }
+
+    it('returns IncogniaAPIError', () => {
+      function dispatchRequest() {
+        handleRequestError(error)
+      }
+
+      expect(dispatchRequest).toThrowError(
+        new IncogniaAPIError(
+          error.message,
+          {
+            statusCode: error.response.status,
+            payload: error.response.data
+          }
+        )
+      )
+    })
+  })
+
+  describe('when the error contains a request', () => {
+
+    const error = {
+      message: 'error message',
+      request: {}
+    }
+
+    it('returns IncogniaAPIError', () => {
+      function dispatchRequest() {
+        handleRequestError(error)
+      }
+
+      expect(dispatchRequest).toThrowError(
+        new IncogniaAPIError(
+          `The request was made but no response was received (${error.message})`
+        )
+      )
+    })
+  })
+
+  describe('when the error is unknown', () => {
+    const error = {
+      message: 'error message'
+    }
+
+    it('returns IncogniaAPIError', () => {
+      function dispatchRequest() {
+        handleRequestError(error)
+      }
+
+      expect(dispatchRequest).toThrowError(
+        new IncogniaError(error.message)
+      )
+    })
+  })
+})

--- a/src/errors.test.js
+++ b/src/errors.test.js
@@ -1,4 +1,4 @@
-import { IncogniaAPIError, IncogniaError, handleRequestError } from './errors'
+import { IncogniaAPIError, IncogniaError, throwCustomRequestError } from './errors'
 
 describe('IncogniaAPIError', () => {
   const error = new IncogniaAPIError('error message')
@@ -35,7 +35,7 @@ describe('IncogniaError', () => {
   })
 })
 
-describe('handleRequestError', () => {
+describe('throwCustomRequestError', () => {
   describe('when the error contains a response', () => {
     const error = {
       message: 'error message',
@@ -47,7 +47,7 @@ describe('handleRequestError', () => {
 
     it('returns IncogniaAPIError', () => {
       function dispatchRequest() {
-        handleRequestError(error)
+        throwCustomRequestError(error)
       }
 
       expect(dispatchRequest).toThrowError(
@@ -71,7 +71,7 @@ describe('handleRequestError', () => {
 
     it('returns IncogniaAPIError', () => {
       function dispatchRequest() {
-        handleRequestError(error)
+        throwCustomRequestError(error)
       }
 
       expect(dispatchRequest).toThrowError(
@@ -89,7 +89,7 @@ describe('handleRequestError', () => {
 
     it('returns IncogniaAPIError', () => {
       function dispatchRequest() {
-        handleRequestError(error)
+        throwCustomRequestError(error)
       }
 
       expect(dispatchRequest).toThrowError(

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import axios from 'axios'
 import { convertObjectToCamelCase } from './formatting'
-import { handleRequestError, IncogniaAPIError, IncogniaError } from './errors'
+import { throwCustomRequestError, IncogniaAPIError, IncogniaError } from './errors'
 
 const Method = {
   POST: 'post',
@@ -102,7 +102,7 @@ export class IncogniaAPI {
       })
       return convertObjectToCamelCase(response.data)
     } catch (e) {
-      handleRequestError(e)
+      throwCustomRequestError(e)
     }
   }
 
@@ -149,11 +149,11 @@ export class IncogniaAPI {
           password: this.clientSecret
         },
         headers: {
-          'Content-Type': 'application/x-www-form-urlencoded'
+          'content-type': 'application/x-www-form-urlencoded'
         }
       })
     } catch (e) {
-      handleRequestError(e)
+      throwCustomRequestError(e)
     }
   }
 }

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -140,7 +140,6 @@ describe('API', () => {
       }
 
       nock(US_BASE_ENDPOINT_URL)
-        .persist()
         .get(`/v2/onboarding/signups/${apiResponse.id}`)
         .reply(200, apiResponse)
 
@@ -165,7 +164,6 @@ describe('API', () => {
       }
 
       nock(US_BASE_ENDPOINT_URL)
-        .persist()
         .post(`/v2/onboarding/signups`)
         .reply(200, apiResponse)
 
@@ -190,7 +188,6 @@ describe('API', () => {
       }
 
       nock(US_BASE_ENDPOINT_URL)
-        .persist()
         .post(`/v2/authentication/transactions`)
         .reply(200, apiResponse)
 


### PR DESCRIPTION

## Exception handling

Every method call can throw `IncogniaAPIError` and `IncogniaError`.

`IncogniaAPIError` is thrown when the API returned an unexpected http status code. You can retrieve it by calling the `statusCode` property, along with the `payload` property, which returns the API response payload that might include additional details.

`IncogniaError` represents unknown errors, like serialization/deserialization errors.

```js
const { IncogniaAPI, IncogniaAPIError } = require('@incognia/api')

try {
  const loginAssessment = await incogniaAPI.registerLoginAssessment({
    installationId: 'installation_id',
    accountId: 'account_id'
  })
} catch (error) {
  if (error instanceof IncogniaAPIError) {
    console.log(error.statusCode)
    console.log(error.payload)
  }
}
```

Review per commit is encouraged. :bulb: 
